### PR TITLE
Updated to be release neutral

### DIFF
--- a/Create-FedoraWSL.ps1
+++ b/Create-FedoraWSL.ps1
@@ -1,10 +1,12 @@
 <#
 .SYNOPSIS
-A script to port Fedora 35 to WSL
+A script to port Fedora to WSL
 .DESCRIPTION
-A simple PowerShell script to port Fedora 35 to WSL
+A simple PowerShell script to port Fedora to WSL
+.PARAMETER ReleaseNum
+Which Fedora release number to download and install
 .PARAMETER Distribution
-What the distro will be called in WSL, by default it will be called Fedora-35
+What the distro will be called in WSL, by default it will be called Fedora
 .PARAMETER Path
 The Path where the distribution will be installed, by default it will be C:\WSL
 .PARAMETER SetDefault
@@ -14,16 +16,20 @@ Install the wslu package for Windows integration
 #>
 
 Param (
-	[String] $Distribution = "Fedora-35",
+	[Parameter(Mandatory=$true)]
+	[Int] $ReleaseNum,
+	[String] $Distribution = "Fedora$ReleaseNum",
 	[System.IO.DirectoryInfo] $Path = "C:\WSL\",
 	[Switch] $SetDefault,
 	[Switch] $Wslu
 )
 
-Invoke-WebRequest -Uri https://dl.fedoraproject.org/pub/fedora/linux/releases/35/Container/x86_64/images/Fedora-Container-Base-35-1.2.x86_64.tar.xz -OutFile Fedora-Container-Base-35-1.2.x86_64.tar.xz
+$File = (Invoke-WebRequest -Uri https://dl.fedoraproject.org/pub/fedora/linux/releases/$ReleaseNum/Container/x86_64/images/).Links.Href | Select-String 'Fedora-Container-Base'
+
+Invoke-WebRequest -Uri https://dl.fedoraproject.org/pub/fedora/linux/releases/$ReleaseNum/Container/x86_64/images/$File -OutFile Fedora-Container-Base-$ReleaseNum.x86_64.tar.xz
 
 If (Get-Command -Name xz -CommandType Application) {
-	xz --decompress --force .\Fedora-Container-Base-35-1.2.x86_64.tar.xz
+	xz --decompress --force .\Fedora-Container-Base-$ReleaseNum.x86_64.tar.xz
 }
 Else {
 	$XzZip = New-TemporaryFile
@@ -36,10 +42,10 @@ Else {
 	[System.IO.Compression.ZipFileExtensions]::ExtractToFile($XzZipFile.GetEntry("bin_x86-64/xz.exe"), $Xz, $True)
 	$XzZipFile.Dispose()
 
-	Start-Process -FilePath $Xz -ArgumentList "--decompress --force .\Fedora-Container-Base-35-1.2.x86_64.tar.xz" -NoNewWindow -Wait
+	Start-Process -FilePath $Xz -ArgumentList "--decompress --force .\Fedora-Container-Base-$ReleaseNum.x86_64.tar.xz" -NoNewWindow -Wait
 	$XzZip, $Xz | Remove-Item
 }
-tar tf .\Fedora-Container-Base-35-1.2.x86_64.tar | Where-Object { $_ -Like "*/layer.tar" } | ForEach-Object { tar xf .\Fedora-Container-Base-35-1.2.x86_64.tar --strip-components=1 "$_" }
+tar tf .\Fedora-Container-Base-$ReleaseNum.x86_64.tar | Where-Object { $_ -Like "*/layer.tar" } | ForEach-Object { tar xf .\Fedora-Container-Base-$ReleaseNum.x86_64.tar --strip-components=1 "$_" }
 
 [String] $Path = $Path.FullName + $Distribution
 If (!(Test-Path -Path "$Path" -PathType Container)) {
@@ -47,16 +53,17 @@ If (!(Test-Path -Path "$Path" -PathType Container)) {
 }
 
 wsl --import "$Distribution" "$Path" layer.tar
-wsl --distribution "$Distribution" --exec mv /etc/yum.repos.d/fedora.repo /etc/yum.repos.d/fedora.repo.rpmsave
-wsl --distribution "$Distribution" --exec dnf -y remove fedora-logos fedora-release fedora-release-notes
-wsl --distribution "$Distribution" --exec mv /etc/yum.repos.d/fedora.repo.rpmsave /etc/yum.repos.d/fedora.repo
-wsl --distribution "$Distribution" --exec dnf -y --releasever 35 install shadow-utils passwd cracklib-dicts sudo generic-logos generic-release generic-release-notes
+wsl --distribution "$Distribution" --exec dnf -y update
+# wsl --distribution "$Distribution" --exec mv /etc/yum.repos.d/fedora.repo /etc/yum.repos.d/fedora.repo.rpmsave
+# wsl --distribution "$Distribution" --exec dnf -y --skip-broken remove fedora-logos fedora-release fedora-release-notes
+# wsl --distribution "$Distribution" --exec mv /etc/yum.repos.d/fedora.repo.rpmsave /etc/yum.repos.d/fedora.repo
+wsl --distribution "$Distribution" --exec dnf -y --skip-broken --releasever $ReleaseNum install shadow-utils passwd cracklib-dicts sudo dnf-plugins-core #generic-logos generic-release generic-release-notes
 If ($Wslu) {
-	wsl --distribution "$Distribution" --exec dnf -y copr enable wslutilities/wslu fedora-35-x86_64
+	wsl --distribution "$Distribution" --exec dnf -y copr enable wslutilities/wslu fedora-$ReleaseNum-x86_64
 	wsl --distribution "$Distribution" --exec dnf -y install wslu
 }
 
-wsl --distribution "$Distribution" --exec bash -c "printf 'UNIX Username: ' && read unixusername && useradd -G wheel `$unixusername && passwd `$unixusername"
+wsl --distribution "$Distribution" --exec bash -c "printf 'UNIX Username: ' && read unixusername && useradd -G wheel `$unixusername && passwd -d `$unixusername"
 
 Get-ItemProperty Registry::HKEY_CURRENT_USER\Software\Microsoft\Windows\CurrentVersion\Lxss\*\ DistributionName | Where-Object -Property DistributionName -eq "$Distribution" | Set-ItemProperty -Name DefaultUid -Value 1000
 


### PR DESCRIPTION
 - Added a mandatory -ReleaseNum param
 - Added mechanism to figure determine filename to download (different per release)
 - Added `dnf update` before installing packages to ensure latest version compatibility
 - Added `dnf-plugins-core` to package install which provides `dnf copr` command
 - Commented out parts dealing with removing Fedora trademarked items (note below)
 - Removed password for new user, which is consistent with Fedora containers and Fedora Toolbox

Trademarks:  In Fedora 36, your lines of code were problematic since there were changes to these packages.  Both `fedora-logos` and `fedora-release-notes` were removed, and I suspect were integrated with `fedora-release`.  But this was workable since I could have them skipped if not present, however in Fedora 36, the `fedora-release` was tied to `sudo` for some reason and I didn't feel it was worth the risk of forcing the removal, at least across multiple versions, so I just removed the  parts of the code that was trying to switch to the generic packages.

On a side note, I really don't think you need to worry about removing the trademarked packages since you are only providing an installer.   If you wanted to host Fedora on the Microsoft Store, then I think it would be necessary to make that change, but not with what you are doing.  And as a very small sample of your userbase, I personally would not want those packages removed from my install in WSL.  I think it best to leave them and let users manually remove the trademarked content after the install.

BTW, thanks for you efforts in writing this script!!!  It saved me from having to write it myself.  :-)  Hope the additions help.  I verified it worked on Fedora 33, 34, 35, and 36.  I would have went back further, but Wslu repo only went back to Fedora 33.